### PR TITLE
upgrade level to 1.4.0 for nodejs 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "convict": "0.6.0",
     "hapi": "8.0.0",
     "hapi-fxa-oauth": "2.0.0",
-    "level": "0.18.0",
+    "level": "1.4.0",
     "mozlog": "1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
@dannycoates - I had this update to level@1.4.0 so this repo would build on nodejs 4.x, but never got around to a PR. So here it is.
